### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/bootloader.conf.j2
+++ b/templates/bootloader.conf.j2
@@ -3,6 +3,7 @@
 # Example of a template of configuration file
 #
 {{ ansible_managed | comment }}
+{{ "system_role:bootloader" | comment(prefix="", postfix="") }}
 [foo]
 foo = {{ bootloader_foo }}
 bar = {{ bootloader_bar }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:bootloader
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.