### PR TITLE
docs: remove Dependencies section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ Example:
 `bootloader_reboot_needed` - default `false` - if `true`, this means
 a reboot is needed to apply the changes made by the role
 
-## Dependencies
-
-A list of other roles hosted on Galaxy should go here, plus any details in
-regards to parameters that may need to be set for other roles, or variables
-that are used from other roles.
-
 ## Example Playbook
 
 Including an example of how to use your role (for instance, with variables


### PR DESCRIPTION
remove unused and confusing Dependencies section from README.md

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
