### PR TITLE
test: ensure facts for tests_include_vars_from_parent.yml

### DIFF
--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,6 +1,7 @@
 ---
 - name: Test roles variables override
   hosts: all
+  gather_facts: true
   tasks:
     - name: Create var file in caller that can override the one in called role
       delegate_to: localhost


### PR DESCRIPTION
This test requires certain facts, so ensure the facts are
present in case the user is running with
`ANSIBLE_GATHERING=explicit` or the equivalent.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
