### PR TITLE
fix: Modify grub timeout in grub config directly

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,9 +12,5 @@
     cat {{ __bootloader_default_grub }}
   changed_when: true
 
-- name: Rebuild grub config
-  command: grub2-mkconfig -o {{ __bootloader_grub_conf }}
-  changed_when: true
-
 - name: Reboot system
   include_tasks: tasks/reboot.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,33 +17,6 @@
     - Fix default kernel boot parameters
     - Reboot system
 
-- name: Get grub directory stat
-  stat:
-    path: "{{ __bootloader_default_grub | dirname }}"
-  register: __bootloader_grub_dir_stat
-
-- name: Ensure grub directory exists
-  file:
-    path: "{{ __bootloader_default_grub | dirname }}"
-    state: directory
-    mode: "{{ __bootloader_grub_dir_stat.stat.exists |
-      ternary(__bootloader_grub_dir_stat.stat.mode, '0755') }}"
-
-- name: Get grub config stat
-  stat:
-    path: "{{ __bootloader_default_grub }}"
-  register: __bootloader_grub_stat
-
-- name: Update boot loader timeout configuration
-  lineinfile:
-    path: "{{ __bootloader_default_grub }}"
-    regexp: '^GRUB_TIMEOUT=.*'
-    line: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
-    create: true
-    mode: "{{ __bootloader_grub_stat.stat.exists |
-      ternary(__bootloader_grub_stat.stat.mode, '0644') }}"
-  notify: Rebuild grub config
-
 - name: Determine platform type
   stat:
     path: /sys/firmware/efi
@@ -59,6 +32,34 @@
     __bootloader_user_conf: >-
       {{ efi_path | ternary(__bootloader_uefi_conf_dir ~ 'user.cfg',
       '/boot/grub2/user.cfg') }}
+
+- name: Get stat of {{ __bootloader_default_grub }}
+  stat:
+    path: "{{ __bootloader_default_grub }}"
+  register: __bootloader_grub_stat
+
+- name: >-
+    Update boot loader timeout configuration in {{ __bootloader_default_grub }}
+  lineinfile:
+    path: "{{ __bootloader_default_grub }}"
+    regexp: '^GRUB_TIMEOUT=.*'
+    line: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
+    create: true
+    mode: "{{ __bootloader_grub_stat.stat.exists |
+      ternary(__bootloader_grub_stat.stat.mode, '0644') }}"
+
+- name: Get stat of {{ __bootloader_grub_conf }}
+  stat:
+    path: "{{ __bootloader_grub_conf }}"
+  register: __bootloader_grub_conf_stat
+
+- name: Update boot loader timeout configuration in {{ __bootloader_grub_conf }}
+  lineinfile:
+    path: "{{ __bootloader_grub_conf }}"
+    regexp: 'set timeout=.*'
+    line: 'set timeout={{ bootloader_timeout }}'
+    mode: "{{ __bootloader_grub_conf_stat.stat.exists |
+      ternary(__bootloader_grub_conf_stat.stat.mode, '0644') }}"
 
 - name: Update boot loader password
   when: bootloader_password is not none

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,11 +40,10 @@
 
 - name: >-
     Update boot loader timeout configuration in {{ __bootloader_default_grub }}
-  lineinfile:
+  replace:
     path: "{{ __bootloader_default_grub }}"
     regexp: '^GRUB_TIMEOUT=.*'
-    line: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
-    create: true
+    replace: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
     mode: "{{ __bootloader_grub_stat.stat.exists |
       ternary(__bootloader_grub_stat.stat.mode, '0644') }}"
 
@@ -54,10 +53,10 @@
   register: __bootloader_grub_conf_stat
 
 - name: Update boot loader timeout configuration in {{ __bootloader_grub_conf }}
-  lineinfile:
+  replace:
     path: "{{ __bootloader_grub_conf }}"
     regexp: 'set timeout=.*'
-    line: 'set timeout={{ bootloader_timeout }}'
+    replace: 'set timeout={{ bootloader_timeout }}'
     mode: "{{ __bootloader_grub_conf_stat.stat.exists |
       ternary(__bootloader_grub_conf_stat.stat.mode, '0644') }}"
 

--- a/tests/tasks/clone_kernel.yml
+++ b/tests/tasks/clone_kernel.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set fact with the default kernel to use for clones
+  set_fact:
+    test_kernel: "{{ bootloader_facts | rejectattr('initrd', 'undefined')
+      | selectattr('default') | first }}"
+
+- name: Clone test_kernel kernel and initrd for test purposes
+  copy:
+    src: "{{ item.src }}"
+    remote_src: true
+    dest: "{{ item.dest }}"
+    mode: preserve
+  loop:
+    - src: "{{ test_kernel.kernel }}"
+      dest: "{{ test_kernel.kernel }}_clone{{ __bootloader_clone_num }}"
+    - src: "{{ test_kernel.initrd | regex_replace(' .*$', '') }}"
+      dest: >-
+        {{ test_kernel.initrd |
+        regex_replace(' .*$', '') }}_clone{{ __bootloader_clone_num }}
+
+- name: Create kernel Clone{{ __bootloader_clone_num }} 
+  vars:
+    bootloader_settings:
+      - kernel:
+          path: "{{ test_kernel.kernel }}_clone{{ __bootloader_clone_num }}"
+          initrd: "{{ test_kernel.initrd |
+            regex_replace(' .*$', '') }}_clone{{ __bootloader_clone_num }}"
+          title: Clone{{ __bootloader_clone_num }}
+        options:
+          - name: test
+            value: kernel
+            state: present
+          - copy_default: "{{ __bootloader_copy_default }}"
+  include_role:
+    name: linux-system-roles.bootloader
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Ensure bootloader_reboot_required is not set to true
+  assert:
+    that: not bootloader_reboot_required
+
+- name: Get bootloader_facts
+  vars:
+    bootloader_gather_facts: true
+  include_role:
+    name: linux-system-roles.bootloader

--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -8,158 +8,100 @@
   vars:
     bootloader_reboot_ok: true
   tasks:
-    - name: Get bootloader_facts
-      vars:
-        bootloader_gather_facts: true
-      include_role:
-        name: linux-system-roles.bootloader
+    - name: Run in a block to clean up afterwards
+      block:
+        - name: Get bootloader_facts
+          vars:
+            bootloader_gather_facts: true
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Skip test on ostree systems
-      meta: end_host
-      when: __bootloader_is_ostree
+        - name: Skip test on ostree systems
+          meta: end_host
+          when: __bootloader_is_ostree
 
-    # Images in CI might have a grub timeout set to a different other than the
-    # default 5 value.
-    # In this case, the above invocation require handlers to be flushed.
-    - name: Flush handlers
-      meta: flush_handlers
+        # Images in CI might have a grub timeout set to a different other than the
+        # default 5 value.
+        # In this case, the above invocation require handlers to be flushed.
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Set fact with the default kernel to use for clones
-      set_fact:
-        test_kernel: "{{ bootloader_facts | rejectattr('initrd', 'undefined')
-          | selectattr('default') | first }}"
+        - name: Clone kernel to Clone1
+          vars:
+            __bootloader_clone_num: 1
+            __bootloader_copy_default: true
+          include_tasks: tasks/clone_kernel.yml
 
-    - name: Clone test_kernel kernel and initrd for test purposes
-      copy:
-        src: "{{ item.src }}"
-        remote_src: true
-        dest: "{{ item.dest }}"
-        mode: preserve
-      loop:
-        - src: "{{ test_kernel.kernel }}"
-          dest: "{{ test_kernel.kernel }}_clone1"
-        - src: "{{ test_kernel.initrd | regex_replace(' .*$', '') }}"
-          dest: "{{ test_kernel.initrd | regex_replace(' .*$', '') }}_clone1"
-        - src: "{{ test_kernel.kernel }}"
-          dest: "{{ test_kernel.kernel }}_clone2"
-        - src: "{{ test_kernel.initrd | regex_replace(' .*$', '') }}"
-          dest: "{{ test_kernel.initrd | regex_replace(' .*$', '') }}_clone2"
+        - name: Verify settings
+          vars:
+            __default_args: "{{
+              (bootloader_facts | selectattr('title', 'defined') |
+              selectattr('default') |
+              first).args }}"
+          assert:
+            that: >-
+              (bootloader_facts | selectattr('title', 'defined') |
+              selectattr('title', 'search', 'Clone1') |
+              first).args == __default_args ~ ' test=kernel'
 
-    - name: Create Clone1 kernel with copy_defaults=true
-      vars:
-        bootloader_settings:
-          - kernel:
-              path: "{{ test_kernel.kernel }}_clone1"
-              initrd: "{{ test_kernel.initrd |
-                regex_replace(' .*$', '') }}_clone1"
-              title: Clone1
-            options:
-              - name: test
-                value: setting
-                state: present
-              - copy_default: true
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: Remove Clone1 kernel with 3 kernel keys
+          vars:
+            bootloader_gather_facts: true
+            bootloader_settings:
+              - kernel:
+                  path: "{{ test_kernel.kernel }}_clone1"
+                  initrd: "{{ test_kernel.initrd |
+                    regex_replace(' .*$', '') }}_clone1"
+                  title: Clone1
+                options:
+                  - name: console
+                    value: tty0
+                    state: present
+                  - copy_default: true
+                state: absent
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Flush handlers
-      meta: flush_handlers
+        - name: Verify that Clone1 kernel is removed
+          assert:
+            that: bootloader_facts | selectattr('title', 'defined') |
+              selectattr('title', 'search', 'Clone1') |
+              list | length == 0
 
-    - name: Ensure bootloader_reboot_required is not set to true
-      assert:
-        that: not bootloader_reboot_required
+        - name: Clone kernel to Clone2
+          vars:
+            __bootloader_clone_num: 2
+            __bootloader_copy_default: false
+          include_tasks: tasks/clone_kernel.yml
 
-    - name: Get bootloader_facts
-      vars:
-        bootloader_gather_facts: true
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: Verify settings
+          assert:
+            that: >-
+              (bootloader_facts | selectattr('title', 'defined') |
+              selectattr('title', 'search', 'Clone2') |
+              first).args == 'test=kernel'
 
-    - name: Verify settings
-      vars:
-        __default_args: "{{
-          (bootloader_facts | selectattr('title', 'defined') |
-          selectattr('default') |
-          first).args }}"
-      assert:
-        that: >-
-          (bootloader_facts | selectattr('title', 'defined') |
-          selectattr('title', 'search', 'Clone1') |
-          first).args == __default_args ~ ' test=setting'
+        - name: Remove Clone2 kernel with kernel path
+          vars:
+            bootloader_gather_facts: true
+            bootloader_settings:
+              - kernel:
+                  path: "{{ test_kernel.kernel }}_clone2"
+                state: absent
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Remove Clone1 kernel with 3 kernel keys
-      vars:
-        bootloader_gather_facts: true
-        bootloader_settings:
-          - kernel:
-              path: "{{ test_kernel.kernel }}_clone1"
-              initrd: "{{ test_kernel.initrd |
-                regex_replace(' .*$', '') }}_clone1"
-              title: Clone1
-            options:
-              - name: console
-                value: tty0
-                state: present
-              - copy_default: true
-            state: absent
-      include_role:
-        name: linux-system-roles.bootloader
-
-    - name: Verify that Clone1 kernel is removed
-      assert:
-        that: bootloader_facts | selectattr('title', 'defined') |
-          selectattr('title', 'search', 'Clone1') |
-          list | length == 0
-
-    - name: Create clone2 kernel without copy_defaults=true
-      vars:
-        bootloader_settings:
-          - kernel:
-              path: "{{ test_kernel.kernel }}_clone2"
-              initrd: "{{ test_kernel.initrd |
-                regex_replace(' .*$', '') }}_clone2"
-              title: Clone2
-            options:
-              - name: console
-                value: tty0
-                state: present
-      include_role:
-        name: linux-system-roles.bootloader
-
-    - name: Flush handlers
-      meta: flush_handlers
-
-    - name: Ensure bootloader_reboot_required is not set to true
-      assert:
-        that: not bootloader_reboot_required
-
-    - name: Get bootloader_facts
-      vars:
-        bootloader_gather_facts: true
-      include_role:
-        name: linux-system-roles.bootloader
-
-    - name: Verify settings
-      assert:
-        that: >-
-          (bootloader_facts | selectattr('title', 'defined') |
-          selectattr('title', 'search', 'Clone2') |
-          first).args == 'console=tty0'
-
-    - name: Remove Clone2 kernel with kernel path
-      vars:
-        bootloader_gather_facts: true
-        bootloader_settings:
-          - kernel:
-              path: "{{ test_kernel.kernel }}_clone2"
-              initrd: "{{ test_kernel.initrd |
-                regex_replace(' .*$', '') }}_clone2"
-              title: Clone2
-            state: absent
-      include_role:
-        name: linux-system-roles.bootloader
-
-    - name: Verify that Clone2 kernel is removed
-      assert:
-        that: bootloader_facts | selectattr('title', 'defined') |
-          selectattr('title', 'search', 'Clone2') |
-          list | length == 0
+        - name: Verify that Clone2 kernel is removed
+          assert:
+            that: bootloader_facts | selectattr('title', 'defined') |
+              selectattr('title', 'search', 'Clone2') |
+              list | length == 0
+      always:
+        - name: Remove cloned kernels
+          command: >-
+            grubby --remove-kernel={{ test_kernel.kernel }}_clone{{ item }}
+          loop:
+            - 1
+            - 2
+          changed_when: true
+          failed_when: false

--- a/tests/tests_password.yml
+++ b/tests/tests_password.yml
@@ -4,31 +4,39 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Set boot loader password
-      vars:
-        bootloader_password: test-pass
-      include_role:
-        name: linux-system-roles.bootloader
+    - name: Run in a block to clean up afterwards
+      block:
+        - name: Set boot loader password
+          vars:
+            bootloader_password: test-pass
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Get contents of {{ __bootloader_user_conf }}
-      command: cat {{ __bootloader_user_conf }}
-      failed_when: >-
-        not (__bootloader_user_conf_content.stdout |
-        regex_search('^GRUB2_PASSWORD=grub\.pbkdf2\.sha512\.10000\..*'))
-      register: __bootloader_user_conf_content
-      changed_when: false
+        - name: Get contents of {{ __bootloader_user_conf }}
+          command: cat {{ __bootloader_user_conf }}
+          failed_when: >-
+            not (__bootloader_user_conf_content.stdout |
+            regex_search('^GRUB2_PASSWORD=grub\.pbkdf2\.sha512\.10000\..*'))
+          register: __bootloader_user_conf_content
+          changed_when: false
 
-    - name: Remove boot loader password
-      vars:
-        bootloader_remove_password: true
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: Remove boot loader password
+          vars:
+            bootloader_remove_password: true
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Get stat of {{ __bootloader_user_conf }}
-      stat:
-        path: "{{ __bootloader_user_conf }}"
-      register: __bootloader_user_conf_stat
+        - name: Get stat of {{ __bootloader_user_conf }}
+          stat:
+            path: "{{ __bootloader_user_conf }}"
+          register: __bootloader_user_conf_stat
 
-    - name: Verify that user conf doesn't exist
-      assert:
-        that: not __bootloader_user_conf_stat.stat.exists
+        - name: Verify that user conf doesn't exist
+          assert:
+            that: not __bootloader_user_conf_stat.stat.exists
+      always:
+        - name: Remove boot loader password
+          vars:
+            bootloader_remove_password: true
+          include_role:
+            name: linux-system-roles.bootloader

--- a/tests/tests_settings.yml
+++ b/tests/tests_settings.yml
@@ -8,148 +8,171 @@
   vars:
     bootloader_reboot_ok: true
   tasks:
-    - name: Get bootloader_facts
-      vars:
-        bootloader_gather_facts: true
-      include_role:
-        name: linux-system-roles.bootloader
+    - name: Run in a block to clean up afterwards
+      block:
+        - name: Get bootloader_facts
+          vars:
+            bootloader_gather_facts: true
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Skip test on ostree systems
-      meta: end_host
-      when: __bootloader_is_ostree
+        - name: Skip test on ostree systems
+          meta: end_host
+          when: __bootloader_is_ostree
 
-    # Images in CI might have a grub timeout set to a different other than the
-    # default 5 value.
-    # In this case, the above invocation require handlers to be flushed.
-    - name: Flush handlers
-      meta: flush_handlers
+        # Images in CI might have a grub timeout set to a different other than
+        # the default 5 value.
+        # In this case, the above invocation require handlers to be flushed.
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Verify that default bootloader is correct in bootloader_gather_facts
-      vars:
-        default_bootloader: "{{
-          (bootloader_facts | selectattr('default') |
-          first).kernel }}"
-      command: grubby --default-kernel
-      changed_when: false
-      register: __default_kernel_cmd
-      failed_when: default_bootloader != __default_kernel_cmd.stdout
+        - name: Clone kernel to Clone1
+          vars:
+            __bootloader_clone_num: 1
+            __bootloader_copy_default: true
+          include_tasks: tasks/clone_kernel.yml
 
-    - name: Replace configuration with settings using kernel index
-      vars:
-        bootloader_gather_facts: true
-        bootloader_settings:
-          - kernel:
-              index: "{{
-                (bootloader_facts | selectattr('index', 'search', '0') |
-                first).index }}"
-            options:
-              - name: console
-                value: tty0
-              - name: print-fatal-signals
-                value: 1
-              - name: no_timer_check
-                state: present
-              - name: quiet
-              - previous: replaced
-          - kernel: ALL
-            options:
-              - name: debug
-                state: present
-        bootloader_timeout: 6
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: >-
+            Verify that default bootloader is correct in bootloader_gather_facts
+          vars:
+            default_bootloader: "{{
+              (bootloader_facts | selectattr('default') |
+              first).kernel }}"
+          command: grubby --default-kernel
+          changed_when: false
+          register: __default_kernel_cmd
+          failed_when: default_bootloader != __default_kernel_cmd.stdout
 
-    - name: Flush handlers
-      meta: flush_handlers
+        - name: Set fact with the test clone
+          set_fact:
+            cloned_kernel: "{{
+              bootloader_facts | selectattr('title', 'defined') |
+              selectattr('title', 'search', 'Clone1') |
+              first }}"
 
-    - name: Ensure bootloader_reboot_required is set to false
-      assert:
-        that: not (bootloader_reboot_required | d(false))
+        - name: Replace configuration with settings using kernel index
+          vars:
+            bootloader_gather_facts: true
+            bootloader_settings:
+              - kernel:
+                  index: "{{ cloned_kernel.index }}"
+                options:
+                  - name: console
+                    value: tty0
+                  - name: print-fatal-signals
+                    value: 1
+                  - name: no_timer_check
+                    state: present
+                  - name: quiet
+                  - previous: replaced
+              - kernel: ALL
+                options:
+                  - name: debug
+                    state: present
+            bootloader_timeout: 6
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Verify settings
-      assert:
-        that: >-
-          (bootloader_facts | selectattr('index', 'search', '0') | first).args |
-          regex_search('^.*console=tty0 print-fatal-signals=1 no_timer_check
-          quiet debug( |)$')
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Verify boot loader timeout configuration
-      command: cat {{ __bootloader_grub_conf }}
-      failed_when: >-
-        not __bootloader_default_grub_content.stdout is regex('set timeout=6')
-      register: __bootloader_default_grub_content
-      changed_when: false
+        - name: Ensure bootloader_reboot_required is set to false
+          assert:
+            that: not (bootloader_reboot_required | d(false))
 
-    - name: Change some settings using kernel title
-      vars:
-        bootloader_gather_facts: true
-        bootloader_settings:
-          - kernel:
-              title: "{{
-                (bootloader_facts | selectattr('index', 'search', '0') |
-                first).title }}"
-            options:
-              - name: quiet
-                state: absent
-              - name: debug
-                state: absent
-        bootloader_timeout: 4
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: Verify settings
+          assert:
+            that: >-
+              (bootloader_facts |
+              selectattr('index', 'search', cloned_kernel.index) | first).args |
+              regex_search('^.*console=tty0 print-fatal-signals=1 no_timer_check
+              quiet debug( |)$')
 
-    - name: Flush handlers
-      meta: flush_handlers
+        - name: Verify boot loader timeout configuration
+          command: cat {{ __bootloader_grub_conf }}
+          failed_when: >-
+            not __bootloader_default_grub_content.stdout is
+            regex('set timeout=6')
+          register: __bootloader_default_grub_content
+          changed_when: false
 
-    - name: Ensure bootloader_reboot_required is set to false
-      assert:
-        that: not (bootloader_reboot_required | d(false))
+        - name: Change some settings using kernel title
+          vars:
+            bootloader_gather_facts: true
+            bootloader_settings:
+              - kernel:
+                  title: "{{ cloned_kernel.title }}"
+                options:
+                  - name: quiet
+                    state: absent
+                  - name: debug
+                    state: absent
+            bootloader_timeout: 4
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Verify settings
-      assert:
-        that: >-
-          (bootloader_facts | selectattr('index', 'search', '0') | first).args |
-          regex_search('^.*console=tty0 print-fatal-signals=1
-          no_timer_check( |)$')
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Verify boot loader timeout configuration
-      command: cat {{ __bootloader_grub_conf }}
-      failed_when: >-
-        not __bootloader_default_grub_content.stdout is regex('set timeout=4')
-      register: __bootloader_default_grub_content
-      changed_when: false
+        - name: Ensure bootloader_reboot_required is set to false
+          assert:
+            that: not (bootloader_reboot_required | d(false))
 
-    - name: Set existing variable using kernel path, should report not changed
-      vars:
-        bootloader_settings:
-          - kernel:
-              path: "{{
-                (bootloader_facts | selectattr('index', 'search', '0') |
-                first).kernel }}"
-            options:
-              - name: console
-                value: tty0
-                state: present
-        bootloader_timeout: 4
-      include_role:
-        name: linux-system-roles.bootloader
+        - name: Verify settings
+          assert:
+            that: >-
+              (bootloader_facts |
+              selectattr('index', 'search', cloned_kernel.index) | first).args |
+              regex_search('^.*console=tty0 print-fatal-signals=1
+              no_timer_check( |)$')
 
-    - name: Flush handlers
-      meta: flush_handlers
+        - name: Verify boot loader timeout configuration
+          command: cat {{ __bootloader_grub_conf }}
+          failed_when: >-
+            not __bootloader_default_grub_content.stdout is
+            regex('set timeout=4')
+          register: __bootloader_default_grub_content
+          changed_when: false
 
-    - name: Ensure bootloader_reboot_required is not set to true
-      assert:
-        that: not bootloader_reboot_required
+        - name: >-
+            Set existing variable using kernel path, should report not changed
+          vars:
+            bootloader_settings:
+              - kernel:
+                  path: "{{ cloned_kernel.kernel }}"
+                options:
+                  - name: console
+                    value: tty0
+                    state: present
+            bootloader_timeout: 4
+          include_role:
+            name: linux-system-roles.bootloader
 
-    - name: Verify settings
-      assert:
-        that: >-
-          (bootloader_facts | selectattr('index', 'search', '0') | first).args
-          | regex_search('^.*console=tty0 print-fatal-signals=1
-          no_timer_check( |)$')
+        - name: Flush handlers
+          meta: flush_handlers
 
-    - name: Verify boot loader timeout configuration
-      command: cat {{ __bootloader_grub_conf }}
-      failed_when: >-
-        not __bootloader_default_grub_content.stdout is regex('set timeout=4')
-      register: __bootloader_default_grub_content
-      changed_when: false
+        - name: Ensure bootloader_reboot_required is not set to true
+          assert:
+            that: not bootloader_reboot_required
+
+        - name: Verify settings
+          assert:
+            that: >-
+              (bootloader_facts |
+              selectattr('index', 'search', cloned_kernel.index) | first).args |
+              regex_search('^.*console=tty0 print-fatal-signals=1
+              no_timer_check( |)$')
+
+        - name: Verify boot loader timeout configuration
+          command: cat {{ __bootloader_grub_conf }}
+          failed_when: >-
+            not __bootloader_default_grub_content.stdout is
+            regex('set timeout=4')
+          register: __bootloader_default_grub_content
+          changed_when: false
+      always:
+        - name: Remove cloned kernels
+          command: >-
+            grubby --remove-kernel={{ test_kernel.kernel }}_clone1
+          changed_when: true
+          failed_when: false


### PR DESCRIPTION
Enhancement: Modify grub timeout in grub config directly

Reason: On RHEL 7, rebuilding grub config with grubby2-mkconfig has a bug that returns previously removed kernels

Result: This workaround doesn't require rebuilding grub config and hence avoids the bug
