### PR TITLE
fix: Fix the role for UEFI systems

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright 2024 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 An Ansible role for bootloader and kernel command line management.
 
+## Supported architectures
+
+This role currently supports configuring `grub2` boot loader which runs on the following architectures:
+
+* AMD and Intel 64-bit architectures (x86-64)
+* The 64-bit ARM architecture (ARMv8.0)
+* IBM Power Systems, Little Endian (POWER9)
+
 ## Requirements
 
 See below

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,13 +10,6 @@
     use: "{{ (__bootloader_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
-- name: Ensure boot loader settings
-  bootloader_settings:
-    bootloader_settings: "{{ bootloader_settings }}"
-  notify:
-    - Fix default kernel boot parameters
-    - Reboot system
-
 - name: Determine platform type
   stat:
     path: /sys/firmware/efi
@@ -36,7 +29,19 @@
 - name: Get stat of {{ __bootloader_default_grub }}
   stat:
     path: "{{ __bootloader_default_grub }}"
-  register: __bootloader_grub_stat
+  register: __bootloader_default_grub_stat
+
+- name: Get stat of {{ __bootloader_grub_conf }}
+  stat:
+    path: "{{ __bootloader_grub_conf }}"
+  register: __bootloader_grub_conf_stat
+
+- name: Use a general grub conf path if UEFI path is a stub
+  when:
+    - __bootloader_grub_conf_stat.stat.size < 500
+    - __bootloader_grub_conf == __bootloader_uefi_conf_dir ~ 'grub.cfg'
+  set_fact:
+    __bootloader_grub_conf: /boot/grub2/grub.cfg
 
 - name: >-
     Update boot loader timeout configuration in {{ __bootloader_default_grub }}
@@ -44,13 +49,8 @@
     path: "{{ __bootloader_default_grub }}"
     regexp: '^GRUB_TIMEOUT=.*'
     replace: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
-    mode: "{{ __bootloader_grub_stat.stat.exists |
-      ternary(__bootloader_grub_stat.stat.mode, '0644') }}"
-
-- name: Get stat of {{ __bootloader_grub_conf }}
-  stat:
-    path: "{{ __bootloader_grub_conf }}"
-  register: __bootloader_grub_conf_stat
+    mode: "{{ __bootloader_default_grub_stat.stat.exists |
+      ternary(__bootloader_default_grub_stat.stat.mode, '0644') }}"
 
 - name: Update boot loader timeout configuration in {{ __bootloader_grub_conf }}
   replace:
@@ -59,6 +59,13 @@
     replace: 'set timeout={{ bootloader_timeout }}'
     mode: "{{ __bootloader_grub_conf_stat.stat.exists |
       ternary(__bootloader_grub_conf_stat.stat.mode, '0644') }}"
+
+- name: Ensure boot loader settings
+  bootloader_settings:
+    bootloader_settings: "{{ bootloader_settings }}"
+  notify:
+    - Fix default kernel boot parameters
+    - Reboot system
 
 - name: Update boot loader password
   when: bootloader_password is not none

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,9 +15,9 @@ __bootloader_packages:
   - grubby
 __bootloader_default_grub: /etc/default/grub
 __bootloader_uefi_conf_dir: >-
-  {%- if ansible_distribution == 'RedHat' -%}
-  /boot/efi/EFI/redhat/
-  {%- elif ansible_distribution in ['SLES', 'SLES_SAP'] -%}
+  {%- if ansible_os_family == 'RedHat' -%}
+  /boot/efi/EFI/{{ ansible_distribution | lower }}/
+  {%- elif ansible_os_family == Suse -%}
   /boot/efi/EFI/BOOT/
   {%- endif -%}
 __bootloader_bios_conf_dir: /boot/grub2/


### PR DESCRIPTION
Enhancement: Fix the role for UEFI systems

Reason: On UEFI systems, grub config might not have a full config, but a stub that redirects to a common config in `/boot/grub2/grub.cfg`.

Result: The role works properly on both BIOS on UEFI systems
