### PR TITLE
fix: Fail on the s390x architecture with a not supported msg

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
 - name: Set platform/version specific variables
   include_tasks: tasks/set_vars.yml
 
+- name: Fail on s390x architecture
+  fail:
+    msg: >-
+      This role does not support s390x architecture.
+      Let us know if you need the role to support it.
+  when: ansible_architecture == 's390x'
+
 - name: Ensure required packages are installed
   package:
     name: "{{ __bootloader_packages }}"

--- a/tests/tasks/assert_fail_on_s390x.yml
+++ b/tests/tasks/assert_fail_on_s390x.yml
@@ -11,3 +11,10 @@
 
     - name: End execution on s390x host to avoid failures in clean up
       meta: end_host
+
+# When this task file is included in a rescue block, and the above task is
+# skipped, Ansible would report success considering that a failure was rescued
+- name: Fail if in a rescue block
+  when: ansible_failed_result is defined
+  fail:
+    msg: "{{ ansible_failed_result }}"

--- a/tests/tasks/assert_fail_on_s390x.yml
+++ b/tests/tasks/assert_fail_on_s390x.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert failure on the s390x architecture
+  when: ansible_architecture == 's390x'
+  block:
+    - name: Assert failure
+      assert:
+        that: __str in ansible_failed_result.msg
+      vars:
+        __str: This role does not support s390x architecture.
+
+    - name: End execution on s390x host to avoid failures in clean up
+      meta: end_host

--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -96,6 +96,9 @@
             that: bootloader_facts | selectattr('title', 'defined') |
               selectattr('title', 'search', 'Clone2') |
               list | length == 0
+      rescue:
+        - name: Assert failure on s390x architecture
+          include_tasks: tasks/assert_fail_on_s390x.yml
       always:
         - name: Remove cloned kernels
           command: >-

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -3,5 +3,12 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   gather_facts: false  # for testing the role fact gathering
-  roles:
-    - linux-system-roles.bootloader
+  tasks:
+    - name: Run in a block to clean up afterwards
+      block:
+        - name: Run with default parameters
+          include_role:
+            name: linux-system-roles.bootloader
+      rescue:
+        - name: Assert failure on s390x architecture
+          include_tasks: tasks/assert_fail_on_s390x.yml

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -49,6 +49,9 @@
             name: caller
           vars:
             roletoinclude: linux-system-roles.bootloader
+      rescue:
+        - name: Assert failure on s390x architecture
+          include_tasks: tasks/assert_fail_on_s390x.yml
       always:
         - name: Cleanup
           file:

--- a/tests/tests_password.yml
+++ b/tests/tests_password.yml
@@ -34,6 +34,9 @@
         - name: Verify that user conf doesn't exist
           assert:
             that: not __bootloader_user_conf_stat.stat.exists
+      rescue:
+        - name: Assert failure on s390x architecture
+          include_tasks: tasks/assert_fail_on_s390x.yml
       always:
         - name: Remove boot loader password
           vars:

--- a/tests/tests_settings.yml
+++ b/tests/tests_settings.yml
@@ -170,6 +170,9 @@
             regex('set timeout=4')
           register: __bootloader_default_grub_content
           changed_when: false
+      rescue:
+        - name: Assert failure on s390x architecture
+          include_tasks: tasks/assert_fail_on_s390x.yml
       always:
         - name: Remove cloned kernels
           command: >-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 ---
 # ansible_facts required by the role
 __bootloader_required_facts:
+  - architecture
   - distribution
   - distribution_major_version
   - distribution_version


### PR DESCRIPTION
Enhancement: Fail on the s390x architecture with a not supported msg

Reason: the bootloader role does not support s390x architecture because s390x uses a different bootloader - not grub2. Currently, the role fails on s390x with grub2-tools rpm not available.

Result: The role fails with a clear error message that s390x is not supported.

Issue Tracker Tickets (Jira or BZ if any): https://issues.redhat.com/browse/SYSROLES-29
