### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -58,7 +58,16 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          if [ "${{ matrix.pyver_os.ver }}" = 2.7 ]; then
+            # newer virtualenv cannot create python2 venvs
+            # newer tox requires newer virtualenv
+            tox='tox<4.15'
+            virtualenv='virtualenv<20.22.0'
+          else
+            tox=tox
+            virtualenv=virtualenv
+          fi
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -73,11 +82,8 @@ jobs:
           toxenvs="py${toxpyver}"
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
-          # We really should either do those checks using the latest
-          # version of python, or in every version of python
           case "$toxpyver" in
-          27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
-          36) toxenvs="${toxenvs},coveralls,black" ;;
+          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/library/bootloader_settings.py
+++ b/library/bootloader_settings.py
@@ -102,7 +102,7 @@ def compare_dicts(dict1, dict2):
     dict2_keys = set(dict2.keys())
     shared_keys = dict1_keys.intersection(dict2_keys)
     diff = {o: (dict1[o], dict2[o]) for o in shared_keys if dict1[o] != dict2[o]}
-    same = set(o for o in shared_keys if dict1[o] == dict2[o])
+    same = list(set(o for o in shared_keys if dict1[o] == dict2[o]))
     return diff, same
 
 
@@ -139,7 +139,8 @@ def get_single_kernel(bootloader_setting_kernel):
 def get_create_kernel(bootloader_setting_kernel):
     """Get kernel in the format expected by 'grubby --add-kernel=' from a multiple-element dict"""
     kernel = ""
-    for key, value in bootloader_setting_kernel.items():
+    for key in sorted(bootloader_setting_kernel.keys()):
+        value = bootloader_setting_kernel[key]
         if key == "path":
             kernel += " --add-kernel=" + escapeval(value)
         elif key == "title":
@@ -222,7 +223,7 @@ def validate_kernels(module, bootloader_setting, bootloader_facts):
         # diff, same = compare_dicts(bootloader_setting["kernel"], fact)
         if diff and same:
             module.fail_json(
-                "A kernel with provided %s already exists and it's other fields are different %s"
+                "A kernel with provided %s already exists and its other fields are different %s"
                 % (same, diff)
             )
         elif not diff and same:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
         dest: "{{ __bootloader_default_grub }}"
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
 
 - name: Determine platform type
   stat:
@@ -118,7 +118,7 @@
       copy:
         content: GRUB2_PASSWORD={{ __bootloader_pass_hash.stdout }}
         dest: "{{ __bootloader_user_conf }}"
-        mode: 0600
+        mode: "0600"
       changed_when: true
       no_log: true
 

--- a/tests/tasks/clone_kernel.yml
+++ b/tests/tasks/clone_kernel.yml
@@ -19,7 +19,7 @@
         {{ test_kernel.initrd |
         regex_replace(' .*$', '') }}_clone{{ __bootloader_clone_num }}
 
-- name: Create kernel Clone{{ __bootloader_clone_num }} 
+- name: Create kernel Clone{{ __bootloader_clone_num }}
   vars:
     bootloader_settings:
       - kernel:

--- a/tests/unit/test_bootloader_settings.py
+++ b/tests/unit/test_bootloader_settings.py
@@ -263,7 +263,7 @@ class InputValidator(unittest.TestCase):
         self.reset_vars()
 
         err = (
-            "A kernel with provided {'path'} already exists and it's other fields are different "
+            "A kernel with provided ['path'] already exists and its other fields are different "
             + "{'title': ('Fedora Linux', 'Fedora Linux (6.5.12-100.fc37.x86_64) 37 (Workstation Edition)')}"
         )
         cmd_args = SETTINGS[6], FACTS
@@ -288,7 +288,7 @@ class InputValidator(unittest.TestCase):
         self.assertEqual(self.kernel_action, "create")
         self.assertEqual(
             self.kernel,
-            "--title='Fedora Linux' --add-kernel=/boot/vmlinuz-6 --initrd=/boot/initramfs-6.6.img",
+            "--initrd=/boot/initramfs-6.6.img --add-kernel=/boot/vmlinuz-6 --title='Fedora Linux'",
         )
         self.reset_vars()
 
@@ -327,7 +327,7 @@ class InputValidator(unittest.TestCase):
             self.mock_module, self.result, SETTINGS[8]["options"], self.kernel
         )
         expected_cmd = (
-            "grubby --title='Fedora Linux' --add-kernel=/boot/vmlinuz-6 --initrd=/boot/initramfs-6.6.img "
+            "grubby --initrd=/boot/initramfs-6.6.img --add-kernel=/boot/vmlinuz-6 --title='Fedora Linux' "
             + "--args='arg_with_str_value=test_value arg_with_int_value=1 arg_without_val arg_with_str_value_absent=test_value "
             + "arg_with_int_value_absent=1 arg_without_val_absent' --copy-default"
         )

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,7 +18,7 @@ __bootloader_default_grub: /etc/default/grub
 __bootloader_uefi_conf_dir: >-
   {%- if ansible_os_family == 'RedHat' -%}
   /boot/efi/EFI/{{ ansible_distribution | lower }}/
-  {%- elif ansible_os_family == Suse -%}
+  {%- elif ansible_os_family == 'Suse' -%}
   /boot/efi/EFI/BOOT/
   {%- endif -%}
 __bootloader_bios_conf_dir: /boot/grub2/


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
