### PR TITLE
ci: Fix broken __default_args detection

### DIFF
--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -39,7 +39,7 @@
           vars:
             __default_args: "{{
               (bootloader_facts | selectattr('title', 'defined') |
-              selectattr('default') |
+              rejectattr('title', 'search', 'Clone1') |
               first).args }}"
           assert:
             that: >-


### PR DESCRIPTION
tests_add_rm clones the current kernel, and then wants to determine `__default_args` from the original kernel. But that's precisely *not* the one which is the default one after cloning (as Clone1 is now the new and current default).

So instead of determining the attributes from the default kernel, select the original kernel by title.

Fixes https://issues.redhat.com/browse/RHELMISC-11212

---

Fixes the failure here: https://github.com/linux-system-roles/bootloader/pull/136#issuecomment-2797628981