### PR TITLE
docs(changelog): version 1.1.4 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.1.4] - 2025-08-08
+--------------------
+
+### Other Changes
+
+- test: Skip all tests on s390x, avoid redundant clean ups (#158)
+
 [1.1.3] - 2025-08-02
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.1.4

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the 1.1.4 release by adding a new changelog entry and updating the README HTML.

Documentation:
- Add changelog entry for version 1.1.4 (2025-08-08) noting tests are skipped on s390x
- Update README HTML to reference version 1.1.4