### PR TITLE
docs(changelog): version 1.2.0 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 Changelog
 =========
 
+[1.2.0] - 2026-04-28
+--------------------
+
+### New Features
+
+- feat: add role fingerprints to syslog (#205)
+
+### Other Changes
+
+- ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing (#184)
+- ci: bump ansible/ansible-lint from 25 to 26 (#185)
+- ci: skip most CI checks if title contains citest skip [citest_skip] (#186)
+- ci: ansible-lint - remove .collection directory from converted collection [citest_skip] (#187)
+- ci: tox-lsr version 3.15.0 [citest_skip] (#188)
+- ci: Add Fedora 43, remove Fedora 41 from Testing Farm CI (#189)
+- ci: bump actions/upload-artifact from 6 to 7 (#193)
+- ci: tox-lsr 3.17.0 - container test improvements, use ansible 2.20 for fedora 43 [citest_skip] (#195)
+- ci: tox-lsr 3.17.1 - previous update broke container tests, this fixes them [citest_skip] (#196)
+- test: ensure role gathers the facts it uses by having test clear_facts before include_role (#197)
+- ci: Bump codecov/codecov-action from 5 to 6 (#199)
+- ci: fix yum repos to use devel site instead of old site name [citest_skip] (#200)
+- ci: use codecov @v6 [citest_skip] (#201)
+- ci: update header for run_role_with_clear_facts [citest_skip] (#202)
+- ci: Comply with Ansible partner certification checking [citest_skip] (#203)
+- ci: ansible-lint requires dependencies to be installed [citest_skip] (#204)
+- test: add role fingerprints to syslog [citest_skip] (#206)
+
 [1.1.6] - 2026-01-07
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.2.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add changelog entry for version 1.2.0, including the new role fingerprint syslog feature and recent CI and testing updates.