### PR TITLE
feat: new variable `bootloader_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Default: `false`
 
 Type: `bool`
 
+### bootloader_secure_logging
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, private keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `bootloader_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+Default: `true`
+
+Type: `bool`
+
 ## Variables Exported by the Role
 
 The role exports the following variables:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ bootloader_remove_password: false
 bootloader_reboot_ok: false
 
 bootloader_gather_facts: false
+bootloader_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,7 +140,7 @@
         | sed -e "s/PBKDF2 hash of your password is //"
       register: __bootloader_pass_hash
       changed_when: true
-      no_log: true
+      no_log: "{{ bootloader_secure_logging }}"
 
     - name: Put boot loader password to {{ __bootloader_user_conf }}
       copy:
@@ -148,7 +148,7 @@
         dest: "{{ __bootloader_user_conf }}"
         mode: "0600"
       changed_when: true
-      no_log: true
+      no_log: "{{ bootloader_secure_logging }}"
 
 - name: Remove boot loader password configuration
   file:


### PR DESCRIPTION
Feature: Introduce the `bootloader_secure_logging` variable that defaults to `true`.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ bootloader_secure_logging }}", allowing users to set bootloader_secure_logging: false for debugging while maintaining secure defaults (true)
  - New variable bootloader_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable secure logging toggle for bootloader-related tasks while keeping secure behavior as the default.

New Features:
- Add a new bootloader_secure_logging boolean variable that controls whether sensitive tasks hide their output via Ansible no_log.

Enhancements:
- Update password-handling tasks to respect the bootloader_secure_logging setting instead of hard-coding no_log, enabling temporary verbose debugging when needed.

Documentation:
- Document the bootloader_secure_logging variable, its default, and guidance on when and how to disable it for debugging.