### PR TITLE
fix: Set mode for bootloader user and grub conf files to 0600

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
         dest: "{{ __bootloader_default_grub }}"
         owner: root
         group: root
-        mode: "0644"
+        mode: "{{ __bootloader_default_grub_mode }}"
 
 - name: Determine platform type
   stat:
@@ -110,15 +110,14 @@
     regexp: '^GRUB_TIMEOUT=.*'
     replace: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
     mode: "{{ __bootloader_default_grub_stat.stat.exists |
-      ternary(__bootloader_default_grub_stat.stat.mode, '0644') }}"
+      ternary(__bootloader_default_grub_stat.stat.mode, __bootloader_default_grub_mode) }}"
 
 - name: Update boot loader timeout configuration in {{ __bootloader_grub_conf }}
   replace:
     path: "{{ __bootloader_grub_conf }}"
     regexp: 'set timeout=.*'
     replace: 'set timeout={{ bootloader_timeout }}'
-    mode: "{{ __bootloader_grub_conf_stat.stat.exists |
-      ternary(__bootloader_grub_conf_stat.stat.mode, '0644') }}"
+    mode: "{{ __bootloader_conf_mode }}"
 
 - name: Ensure boot loader settings
   bootloader_settings:
@@ -146,7 +145,7 @@
       copy:
         content: GRUB2_PASSWORD={{ __bootloader_pass_hash.stdout }}
         dest: "{{ __bootloader_user_conf }}"
-        mode: "0600"
+        mode: "{{ __bootloader_conf_mode }}"
       changed_when: true
       no_log: "{{ bootloader_secure_logging }}"
 

--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -154,4 +154,7 @@
             - 2
           changed_when: true
           failed_when: false
+          when:
+            - __default_kernel is defined
+            - __default_kernel.kernel is defined
           tags: tests::cleanup

--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -144,6 +144,7 @@
             - __default_kernel is defined
             - __default_kernel.kernel is defined
           failed_when: false
+          tags: tests::cleanup
 
         - name: Remove cloned kernels
           command: >-
@@ -153,3 +154,4 @@
             - 2
           changed_when: true
           failed_when: false
+          tags: tests::cleanup

--- a/tests/tests_add_rm.yml
+++ b/tests/tests_add_rm.yml
@@ -136,6 +136,15 @@
             - Clone1
             - Clone2
       always:
+        # grubby might select the debug kernel to be default and won't boot
+        - name: Restore the original default kernel
+          command: grubby --set-default={{ __default_kernel.kernel }}
+          changed_when: true
+          when:
+            - __default_kernel is defined
+            - __default_kernel.kernel is defined
+          failed_when: false
+
         - name: Remove cloned kernels
           command: >-
             grubby --remove-kernel={{ __default_kernel.kernel }}_clone{{ item }}

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -59,3 +59,4 @@
           loop: "{{ __varfiles_created.results }}"
           delegate_to: localhost
           when: inventory_hostname == ansible_play_hosts_all[0]
+          tags: tests::cleanup

--- a/tests/tests_password.yml
+++ b/tests/tests_password.yml
@@ -52,3 +52,4 @@
           vars:
             bootloader_remove_password: true
           include_tasks: tasks/run_role_with_clear_facts.yml
+          tags: tests::cleanup

--- a/tests/tests_password.yml
+++ b/tests/tests_password.yml
@@ -11,6 +11,7 @@
         - name: Set boot loader password
           vars:
             bootloader_password: test-pass
+            __sr_public: true
           include_tasks: tasks/run_role_with_clear_facts.yml
 
         - name: Get contents of {{ __bootloader_user_conf }}
@@ -20,6 +21,18 @@
             regex_search('^GRUB2_PASSWORD=grub\.pbkdf2\.sha512\.10000\..*'))
           register: __bootloader_user_conf_content
           changed_when: false
+
+        - name: Verify mode of bootloader config files
+          stat:
+            path: "{{ item.file }}"
+          register: __bootloader_conf_stat
+          changed_when: false
+          failed_when: __bootloader_conf_stat.stat.mode != item.mode
+          loop:
+            - file: "{{ __bootloader_grub_conf }}"
+              mode: "{{ __bootloader_conf_mode }}"
+            - file: "{{ __bootloader_user_conf }}"
+              mode: "{{ __bootloader_conf_mode }}"
 
         - name: Remove boot loader password
           vars:

--- a/tests/tests_settings.yml
+++ b/tests/tests_settings.yml
@@ -194,3 +194,4 @@
             grubby --remove-kernel={{ __default_kernel.kernel }}_clone1
           changed_when: true
           failed_when: false
+          tags: tests::cleanup

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,6 +15,11 @@ __bootloader_required_facts_subsets: "{{ ['!all', '!min'] +
 __bootloader_packages:
   - grubby
 __bootloader_default_grub: /etc/default/grub
+# Mode for default grub file, it doesn't fall under CIS Benchmark 1.4.2
+__bootloader_default_grub_mode: '0644'
+# Mode for bootloader grub and user conf files according to CIS benchmarks
+# CIS Benchmark 1.4.2 Ensure access to bootloader config is configured
+__bootloader_conf_mode: '0600'
 __bootloader_uefi_conf_dir: >-
   {%- if ansible_facts['os_family'] == 'RedHat' -%}
   /boot/efi/EFI/{{ ansible_facts['distribution'] | lower }}/


### PR DESCRIPTION
Enhancement: Set mode for bootloader user and grub conf files to 0600

Reason: Due to CIS Benchmark `1.4.2 Ensure access to bootloader config is configured`, mode of grub config files should be `0600`. Default grub config doesn't fall under this benchmark, its default mode is 0644. CIS Benchmar PDF is available upon registering at https://www.cisecurity.org/cis-benchmarks

Result: The mode of grub conf and user conf is set to 0600 

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHEL-184795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized file permission handling for bootloader configuration artifacts using dedicated, configuration-driven permission settings.
  * Ensured the GRUB default file and the GRUB/user configuration files consistently receive the expected secure modes.
* **Tests**
  * Extended password/config tests to validate the exact file modes of the generated bootloader configuration files.
  * Improved test cleanup by restoring the system’s original default kernel after removing cloned kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->