### PR TITLE
fix: Fix the role running grubby commands in check mode

### DIFF
--- a/library/bootloader_settings.py
+++ b/library/bootloader_settings.py
@@ -298,6 +298,18 @@ def get_boot_args(kernel_info):
     return args.group(1).strip()
 
 
+def apply_command(module, result, cmd):
+    """Run a grubby write command, or only record it in check mode.
+
+    Read-only grubby commands (for example --info, --default-kernel) must
+    call module.run_command() directly so they still run in check mode.
+    """
+    result["changed"] = True
+    result["actions"].append(cmd)
+    if not module.check_mode:
+        module.run_command(cmd)
+
+
 def rm_boot_args(module, result, kernel_info, kernel):
     """Remove all existing args for a kernel"""
     bootloader_args = get_boot_args(kernel_info)
@@ -307,9 +319,7 @@ def rm_boot_args(module, result, kernel_info, kernel):
         + " --remove-args="
         + escapeval(bootloader_args)
     )
-    _unused, stdout, _unused = module.run_command(cmd)
-    result["changed"] = True
-    result["actions"].append(cmd)
+    apply_command(module, result, cmd)
 
 
 def get_setting_name(kernel_setting):
@@ -367,9 +377,7 @@ def add_kernel(module, result, bootloader_setting, kernel):
     if bootloader_setting_default:
         args += " --make-default"
     cmd = "grubby %s %s" % (kernel, args.strip())
-    _unused, stdout, _unused = module.run_command(cmd)
-    result["changed"] = True
-    result["actions"].append(cmd)
+    apply_command(module, result, cmd)
 
 
 def mod_boot_args(module, result, bootloader_setting, kernel, kernel_info):
@@ -423,9 +431,7 @@ def mod_boot_args(module, result, bootloader_setting, kernel, kernel_info):
         boot_mod_args += " --args=" + escapeval(boot_present_args.strip())
     if boot_mod_args:
         cmd = "grubby --update-kernel=" + kernel + boot_mod_args
-        _unused, stdout, _unused = module.run_command(cmd)
-        result["changed"] = True
-        result["actions"].append(cmd)
+        apply_command(module, result, cmd)
     else:
         result["changed"] = False
 
@@ -446,17 +452,13 @@ def mod_default_kernel(module, result, bootloader_setting, kernel_info):
         return
 
     cmd = "grubby --set-default=" + kernel
-    _unused, stdout, _unused = module.run_command(cmd)
-    result["changed"] = True
-    result["actions"].append(cmd)
+    apply_command(module, result, cmd)
 
 
 def rm_kernel(module, result, kernel):
     """Remove a kernel"""
     cmd = "grubby --remove-kernel=%s" % kernel
-    _unused, stdout, _unused = module.run_command(cmd)
-    result["changed"] = True
-    result["actions"].append(cmd)
+    apply_command(module, result, cmd)
 
 
 def get_default_kernel(module, type):

--- a/tests/unit/test_bootloader_settings.py
+++ b/tests/unit/test_bootloader_settings.py
@@ -179,6 +179,7 @@ class InputValidator(unittest.TestCase):
     mock_module = MagicMock(
         run_command=MagicMock(return_value=("test_rc", "test_stdout", "test_err")),
         fail_json=MagicMock(side_effect=SystemExit),
+        check_mode=False,
     )
     result = dict(changed=False, actions=list())
     kernel = None
@@ -187,6 +188,7 @@ class InputValidator(unittest.TestCase):
     def reset_vars(self):
         self.mock_module.run_command.reset_mock()
         self.mock_module.fail_json.reset_mock()
+        self.mock_module.check_mode = False
         self.result = dict(changed=False, actions=list())
         try:
             del self.kernel
@@ -914,4 +916,121 @@ root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"'''
             self.mock_module.fail_json.assert_called_once_with(
                 msg="Type must be one of 'kernel', 'title', or 'index'"
             )
+        self.reset_vars()
+
+    def test_check_mode_skips_write_commands_only(self):
+        """Test that check mode skips write grubby commands but runs reads"""
+        self.reset_vars()
+        self.mock_module.check_mode = True
+
+        bootloader_settings.mod_boot_args(
+            self.mock_module,
+            self.result,
+            SETTINGS[12],
+            KERNELS[7]["kernel"],
+            INFO,
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(len(self.result["actions"]), 1)
+        self.assertTrue(
+            self.result["actions"][0].startswith("grubby --update-kernel=ALL")
+        )
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        bootloader_settings.add_kernel(
+            self.mock_module,
+            self.result,
+            SETTINGS[8],
+            bootloader_settings.get_create_kernel(SETTINGS[8]["kernel"]),
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(len(self.result["actions"]), 1)
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        bootloader_settings.rm_kernel(
+            self.mock_module,
+            self.result,
+            bootloader_settings.get_single_kernel(SETTINGS[3]["kernel"]),
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(len(self.result["actions"]), 1)
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        bootloader_settings.rm_boot_args(self.mock_module, self.result, INFO, "0")
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(len(self.result["actions"]), 1)
+        self.reset_vars()
+
+        kernel_info_with_kernel = '''index=0
+kernel="/boot/vmlinuz-6.5.12-100.fc37.x86_64"
+args="ro rootflags=subvol=root rhgb quiet"
+root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"
+initrd="/boot/initramfs-6.5.12-100.fc37.x86_64.img"
+title="Fedora Linux (6.5.12-100.fc37.x86_64) 37 (Workstation Edition)"
+id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
+        bootloader_setting = {
+            "kernel": {"path": "/boot/vmlinuz-6.5.12-100.fc37.x86_64"},
+            "default": True,
+        }
+        self.mock_module.check_mode = True
+        self.mock_module.run_command.return_value = ("0", "/boot/vmlinuz-different", "")
+        bootloader_settings.mod_default_kernel(
+            self.mock_module, self.result, bootloader_setting, kernel_info_with_kernel
+        )
+        self.mock_module.run_command.assert_called_once_with("grubby --default-kernel")
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(len(self.result["actions"]), 1)
+        self.assertTrue(self.result["actions"][0].startswith("grubby --set-default="))
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        bootloader_settings.mod_boot_args(
+            self.mock_module,
+            self.result,
+            SETTINGS[12],
+            str(KERNELS[1]["kernel"]["kernel_index"]),
+            INFO_SAME_ARGS,
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], False)
+        self.assertEqual(self.result["actions"], [])
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        self.mock_module.run_command.return_value = ("0", "2", "")
+        bootloader_settings.get_default_kernel(self.mock_module, "index")
+        self.mock_module.run_command.assert_called_once_with("grubby --default-index")
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        duplicate_console_setting = {
+            "kernel": "ALL",
+            "options": [{"name": "console", "value": "ttyS0"}],
+        }
+        info_without_console = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="ro rhgb quiet"
+title="Fedora Linux"
+"""
+        bootloader_settings.mod_boot_args(
+            self.mock_module,
+            self.result,
+            duplicate_console_setting,
+            "ALL",
+            info_without_console,
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(
+            self.result["actions"],
+            ["grubby --update-kernel=ALL --args=console=ttyS0"],
+        )
         self.reset_vars()


### PR DESCRIPTION
Enhancement: Fix the role running grubby commands in check mode

Reason: bootloader_setting module was running grubby commands unconditionally.

Result: `grubby` write operations run only when check_mode=False. 

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHEL-180862
Fixes #190

Assisted-by: Cursor AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved check mode behavior for bootloader updates.
  * Write operations are now skipped in check mode while planned actions and change status remain accurately reported.
  * Consolidated kernel removal handling for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->