### PR TITLE
fix: Fix incorrect changed reporting in bootloader_settings module

### DIFF
--- a/library/bootloader_settings.py
+++ b/library/bootloader_settings.py
@@ -304,7 +304,6 @@ def apply_command(module, result, cmd):
     Read-only grubby commands (for example --info, --default-kernel) must
     call module.run_command() directly so they still run in check mode.
     """
-    result["changed"] = True
     result["actions"].append(cmd)
     if not module.check_mode:
         module.run_command(cmd)
@@ -313,6 +312,8 @@ def apply_command(module, result, cmd):
 def rm_boot_args(module, result, kernel_info, kernel):
     """Remove all existing args for a kernel"""
     bootloader_args = get_boot_args(kernel_info)
+    if not bootloader_args:
+        return
     cmd = (
         "grubby --update-kernel="
         + kernel
@@ -432,8 +433,6 @@ def mod_boot_args(module, result, bootloader_setting, kernel, kernel_info):
     if boot_mod_args:
         cmd = "grubby --update-kernel=" + kernel + boot_mod_args
         apply_command(module, result, cmd)
-    else:
-        result["changed"] = False
 
 
 def mod_default_kernel(module, result, bootloader_setting, kernel_info):
@@ -467,6 +466,35 @@ def get_default_kernel(module, type):
     cmd = "grubby --default-" + type
     _unused, stdout, _unused = module.run_command(cmd)
     return stdout.strip()
+
+
+def get_replaced_args(bootloader_setting_options):
+    """Get the sorted list of desired arg tokens for a replacement check."""
+    tokens = []
+    duplicate_names = get_duplicate_present_option_names(bootloader_setting_options)
+    seen_dup_tokens = set()
+    for opt in bootloader_setting_options:
+        setting_name = get_setting_name(opt)
+        if not setting_name:
+            continue
+        if opt.get("state", "present") == "absent":
+            continue
+        name = opt.get("name", "")
+        if name in duplicate_names:
+            if setting_name not in seen_dup_tokens:
+                seen_dup_tokens.add(setting_name)
+                tokens.append(setting_name)
+        else:
+            tokens.append(setting_name)
+    return sorted(tokens)
+
+
+def needs_replacement(bootloader_setting_options, kernel_info):
+    """Check if a 'previous: replaced' operation would actually change the args."""
+    current_args = get_boot_args(kernel_info)
+    current_tokens = sorted(current_args.split()) if current_args else []
+    desired_tokens = get_replaced_args(bootloader_setting_options)
+    return current_tokens != desired_tokens
 
 
 def run_module():
@@ -508,7 +536,8 @@ def run_module():
             and {"previous": "replaced"} in bootloader_setting["options"]
         ) and (kernel_action != "remove"):
             rc, kernel_info, stderr = module.run_command("grubby --info=" + kernel)
-            rm_boot_args(module, result, kernel_info, kernel)
+            if needs_replacement(bootloader_setting.get("options", []), kernel_info):
+                rm_boot_args(module, result, kernel_info, kernel)
 
         # Create a kernel with provided options
         if kernel_action == "create":
@@ -528,8 +557,7 @@ def run_module():
         if kernel_action == "remove":
             rm_kernel(module, result, kernel)
 
-    # in the event of a successful module execution, you will want to
-    # simple AnsibleModule.exit_json(), passing the key/value results
+    result["changed"] = len(result["actions"]) > 0
     module.exit_json(**result)
 
 

--- a/tests/unit/test_bootloader_settings.py
+++ b/tests/unit/test_bootloader_settings.py
@@ -325,7 +325,7 @@ class InputValidator(unittest.TestCase):
             + "arg_with_int_value_absent=1 arg_without_val_absent' --copy-default"
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -354,7 +354,7 @@ class InputValidator(unittest.TestCase):
             + "--args='console=tty0 quiet' --make-default"
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd_with_default)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd_with_default)
         self.reset_vars()
 
@@ -383,7 +383,7 @@ class InputValidator(unittest.TestCase):
             + "--args=console=tty0 --copy-default --make-default"
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd_both)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd_both)
         self.reset_vars()
 
@@ -411,7 +411,7 @@ class InputValidator(unittest.TestCase):
             + "--make-default"
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd_no_options)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd_no_options)
         self.reset_vars()
 
@@ -426,7 +426,7 @@ class InputValidator(unittest.TestCase):
         bootloader_settings.rm_kernel(self.mock_module, self.result, self.kernel)
         expected_cmd = "grubby --remove-kernel=1"
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -452,7 +452,7 @@ class InputValidator(unittest.TestCase):
             + "'arg_with_str_value_absent=test_value arg_with_int_value_absent=1 arg_without_val_absent'"
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -557,7 +557,6 @@ title="Fedora Linux"
             info_both_consoles,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.reset_vars()
 
         duplicate_same_value_setting = {
@@ -587,7 +586,6 @@ title="Fedora Linux"
             info_one_console,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.reset_vars()
 
     def test_mod_boot_args(self):
@@ -606,7 +604,7 @@ title="Fedora Linux"
         )
         expected_cmd = "grubby --update-kernel=2 " + args
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -619,7 +617,7 @@ title="Fedora Linux"
         )
         expected_cmd = "grubby --update-kernel=/path/3 " + args
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -637,7 +635,7 @@ title="Fedora Linux"
             + args
         )
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -650,7 +648,7 @@ title="Fedora Linux"
         )
         expected_cmd = "grubby --update-kernel=DEFAULT " + args
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -663,7 +661,7 @@ title="Fedora Linux"
         )
         expected_cmd = "grubby --update-kernel=ALL " + args
         self.mock_module.run_command.assert_called_once_with(expected_cmd)
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"][0], expected_cmd)
         self.reset_vars()
 
@@ -675,7 +673,6 @@ title="Fedora Linux"
             INFO_SAME_ARGS,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"], [])
         self.reset_vars()
 
@@ -852,7 +849,7 @@ id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
         self.mock_module.run_command.assert_any_call(
             "grubby --set-default=/boot/vmlinuz-6.5.12-100.fc37.x86_64"
         )
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(
             self.result["actions"][0],
             "grubby --set-default=/boot/vmlinuz-6.5.12-100.fc37.x86_64",
@@ -873,7 +870,6 @@ id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
         # Should only call once to get current default, not call set-default
         self.assertEqual(self.mock_module.run_command.call_count, 1)
         self.mock_module.run_command.assert_called_with("grubby --default-kernel")
-        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"], [])
         self.reset_vars()
 
@@ -891,7 +887,6 @@ id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
         )
 
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"], [])
         self.reset_vars()
 
@@ -905,7 +900,6 @@ root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"'''
         )
 
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"], [])
         self.reset_vars()
 
@@ -931,7 +925,7 @@ root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"'''
             INFO,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(len(self.result["actions"]), 1)
         self.assertTrue(
             self.result["actions"][0].startswith("grubby --update-kernel=ALL")
@@ -946,7 +940,7 @@ root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"'''
             bootloader_settings.get_create_kernel(SETTINGS[8]["kernel"]),
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(len(self.result["actions"]), 1)
         self.reset_vars()
 
@@ -957,14 +951,14 @@ root="UUID=65c70529-e9ad-4778-9001-18fe8c525285"'''
             bootloader_settings.get_single_kernel(SETTINGS[3]["kernel"]),
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(len(self.result["actions"]), 1)
         self.reset_vars()
 
         self.mock_module.check_mode = True
         bootloader_settings.rm_boot_args(self.mock_module, self.result, INFO, "0")
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], True)
+        self.assertEqual(self.result["changed"], False)
         self.assertEqual(len(self.result["actions"]), 1)
         self.reset_vars()
 
@@ -985,7 +979,6 @@ id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
             self.mock_module, self.result, bootloader_setting, kernel_info_with_kernel
         )
         self.mock_module.run_command.assert_called_once_with("grubby --default-kernel")
-        self.assertEqual(self.result["changed"], True)
         self.assertEqual(len(self.result["actions"]), 1)
         self.assertTrue(self.result["actions"][0].startswith("grubby --set-default="))
         self.reset_vars()
@@ -999,7 +992,6 @@ id="c44543d15b2c4e898912c2497f734e67-6.5.12-100.fc37.x86_64"'''
             INFO_SAME_ARGS,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], False)
         self.assertEqual(self.result["actions"], [])
         self.reset_vars()
 
@@ -1028,9 +1020,151 @@ title="Fedora Linux"
             info_without_console,
         )
         self.mock_module.run_command.assert_not_called()
-        self.assertEqual(self.result["changed"], True)
         self.assertEqual(
             self.result["actions"],
             ["grubby --update-kernel=ALL --args=console=ttyS0"],
         )
         self.reset_vars()
+
+    def test_apply_command_records_action(self):
+        """Test that apply_command records commands but does not set changed"""
+        self.reset_vars()
+        bootloader_settings.apply_command(
+            self.mock_module, self.result, "grubby --test"
+        )
+        self.assertEqual(self.result["actions"], ["grubby --test"])
+        self.assertFalse(self.result["changed"])
+        self.mock_module.run_command.assert_called_once_with("grubby --test")
+        self.reset_vars()
+
+        self.mock_module.check_mode = True
+        bootloader_settings.apply_command(
+            self.mock_module, self.result, "grubby --test"
+        )
+        self.assertEqual(self.result["actions"], ["grubby --test"])
+        self.assertFalse(self.result["changed"])
+        self.mock_module.run_command.assert_not_called()
+        self.reset_vars()
+
+    def test_rm_boot_args_empty(self):
+        """Test that rm_boot_args does nothing when there are no args"""
+        self.reset_vars()
+        kernel_info_empty = """
+index=0
+kernel="/boot/vmlinuz-test"
+args=""
+title="Fedora Linux"
+"""
+        bootloader_settings.rm_boot_args(
+            self.mock_module, self.result, kernel_info_empty, "0"
+        )
+        self.mock_module.run_command.assert_not_called()
+        self.assertEqual(self.result["actions"], [])
+        self.reset_vars()
+
+    def test_get_replaced_args(self):
+        """Test get_replaced_args builds correct sorted token list"""
+        options = [
+            {"previous": "replaced"},
+            {"name": "quiet"},
+            {"name": "console", "value": "tty0"},
+            {"name": "debug", "state": "absent"},
+        ]
+        result = bootloader_settings.get_replaced_args(options)
+        self.assertEqual(result, ["console=tty0", "quiet"])
+
+        options_dup = [
+            {"previous": "replaced"},
+            {"name": "console", "value": "tty0"},
+            {"name": "console", "value": "ttyS0"},
+            {"name": "quiet"},
+        ]
+        result = bootloader_settings.get_replaced_args(options_dup)
+        self.assertEqual(result, ["console=tty0", "console=ttyS0", "quiet"])
+
+        options_empty = [{"previous": "replaced"}]
+        result = bootloader_settings.get_replaced_args(options_empty)
+        self.assertEqual(result, [])
+
+    def test_needs_replacement(self):
+        """Test needs_replacement for 'previous: replaced' idempotency"""
+        options = [
+            {"previous": "replaced"},
+            {"name": "quiet"},
+            {"name": "console", "value": "tty0"},
+        ]
+
+        kernel_info_match = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="quiet console=tty0"
+title="Fedora Linux"
+"""
+        self.assertFalse(
+            bootloader_settings.needs_replacement(options, kernel_info_match)
+        )
+
+        kernel_info_reordered = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="console=tty0 quiet"
+title="Fedora Linux"
+"""
+        self.assertFalse(
+            bootloader_settings.needs_replacement(options, kernel_info_reordered)
+        )
+
+        kernel_info_extra = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="quiet console=tty0 extra"
+title="Fedora Linux"
+"""
+        self.assertTrue(
+            bootloader_settings.needs_replacement(options, kernel_info_extra)
+        )
+
+        kernel_info_missing = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="quiet"
+title="Fedora Linux"
+"""
+        self.assertTrue(
+            bootloader_settings.needs_replacement(options, kernel_info_missing)
+        )
+
+        kernel_info_empty = """
+index=0
+kernel="/boot/vmlinuz-test"
+args=""
+title="Fedora Linux"
+"""
+        self.assertTrue(
+            bootloader_settings.needs_replacement(options, kernel_info_empty)
+        )
+
+        options_all_absent = [
+            {"previous": "replaced"},
+            {"name": "debug", "state": "absent"},
+        ]
+        self.assertFalse(
+            bootloader_settings.needs_replacement(options_all_absent, kernel_info_empty)
+        )
+
+        options_with_absent = [
+            {"previous": "replaced"},
+            {"name": "quiet"},
+            {"name": "debug", "state": "absent"},
+        ]
+        kernel_info_with_debug = """
+index=0
+kernel="/boot/vmlinuz-test"
+args="quiet debug"
+title="Fedora Linux"
+"""
+        self.assertTrue(
+            bootloader_settings.needs_replacement(
+                options_with_absent, kernel_info_with_debug
+            )
+        )


### PR DESCRIPTION
Enhancement: Fix the module reporting incorrect changed status in several cases

Reason: Sometimes the role reported incorrect changed status.

Result: Now changed is computed once after the loop from the actions list. Add needs_replacement() to skip the remove+re-add cycle for previous: replaced when current args already match desired args.

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHEL-180862

Assisted-by: Cursor AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary bootloader updates when replacement arguments already match the current configuration, including correct handling of reordered tokens.
  * Hardened boot-argument removal to safely do nothing when there are no existing boot arguments.
  * Improved “changed” reporting so it reflects whether any bootloader actions were actually prepared/executed.
* **Tests**
  * Expanded unit tests for replacement token construction, idempotency, no-op behavior with empty arguments, and correct action/change tracking (including check mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->