### PR TITLE
fix!: Do not enforce bootloader timeout default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ Type: `dict`
 
 Use this variable to customize the loading time of the GRUB bootloader.
 
-Default: `5`
+Usually the native setting for timeout is `5`.
+
+When this variable is not set by a user, the role doesn't change the timeout setting.
+
+Default: `null`
 
 Type: `int`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 bootloader_settings: []
-bootloader_timeout: 5
+bootloader_timeout: null
 
 bootloader_password: null
 bootloader_remove_password: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,21 +103,31 @@
         __bootloader_grub_conf: /boot/grub2/grub.cfg
         __bootloader_user_conf: /boot/grub2/user.cfg
 
-- name: >-
-    Update boot loader timeout configuration in {{ __bootloader_default_grub }}
-  replace:
-    path: "{{ __bootloader_default_grub }}"
-    regexp: '^GRUB_TIMEOUT=.*'
-    replace: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
-    mode: "{{ __bootloader_default_grub_stat.stat.exists |
-      ternary(__bootloader_default_grub_stat.stat.mode, __bootloader_default_grub_mode) }}"
+    - name: Ensure secure permissions for bootloader grub config
+      file:
+        path: "{{ __bootloader_grub_conf }}"
+        owner: root
+        group: root
+        mode: "{{ __bootloader_conf_mode }}"
 
-- name: Update boot loader timeout configuration in {{ __bootloader_grub_conf }}
-  replace:
-    path: "{{ __bootloader_grub_conf }}"
-    regexp: 'set timeout=.*'
-    replace: 'set timeout={{ bootloader_timeout }}'
-    mode: "{{ __bootloader_conf_mode }}"
+- name: Update boot loader timeout configuration
+  when: bootloader_timeout is not none
+  block:
+    - name: Update timeout configuration in {{ __bootloader_default_grub }}
+      replace:
+        path: "{{ __bootloader_default_grub }}"
+        regexp: '^GRUB_TIMEOUT=.*'
+        replace: 'GRUB_TIMEOUT={{ bootloader_timeout }}'
+        mode: "{{ __bootloader_default_grub_stat.stat.exists |
+          ternary(__bootloader_default_grub_stat.stat.mode,
+          __bootloader_default_grub_mode) }}"
+
+    - name: Update timeout configuration in {{ __bootloader_grub_conf }}
+      replace:
+        path: "{{ __bootloader_grub_conf }}"
+        regexp: 'set timeout=.*'
+        replace: 'set timeout={{ bootloader_timeout }}'
+        mode: "{{ __bootloader_conf_mode }}"
 
 - name: Ensure boot loader settings
   bootloader_settings:


### PR DESCRIPTION
Enhancement: Do not enforce bootloader timeout default

Reason: In the scenario where users manually change the timeout to be different than the default 5, the role force overwrites this setting to the default value of the bootloader_timeout variable.

Result: This fix sets the bootloader_timeout to null by default, so that the role changes the timeout only when users specify value for the bootloader_timeout variable in their playbook.

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHEL-211556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default bootloader timeout behavior to be unset, so GRUB timeout values are not modified unless configured.
  * GRUB timeout updates now apply only when a timeout is explicitly set (covers both GRUB timeout representations).
  * Improved bootloader and user GRUB configuration ownership and permissions for safer operation.
* **Documentation**
  * Updated `bootloader_timeout` docs to reflect the new default (`null`) and clarify that the role only changes GRUB timeout when you set it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->